### PR TITLE
Make neutering tools optional

### DIFF
--- a/src/main/java/com/oitsjustjose/natprog/common/config/CommonConfig.java
+++ b/src/main/java/com/oitsjustjose/natprog/common/config/CommonConfig.java
@@ -17,6 +17,7 @@ public class CommonConfig {
 
     public static ForgeConfigSpec.IntValue MAX_PEBBLES_PER_CHUNK;
     public static ForgeConfigSpec.IntValue MAX_TWIGS_PER_CHUNK;
+    public static ForgeConfigSpec.BooleanValue TOOL_NEUTERING;
     public static ForgeConfigSpec.BooleanValue REMOVE_WOODEN_TOOL_FUNC;
     public static ForgeConfigSpec.BooleanValue REMOVE_STONE_TOOL_FUNC;
     public static ForgeConfigSpec.BooleanValue MAKE_GROUND_BLOCKS_HARDER;
@@ -52,6 +53,9 @@ public class CommonConfig {
         MAX_TWIGS_PER_CHUNK = COMMON_BUILDER
                 .comment("The maximum number of twigs that can be found in each chunk")
                 .defineInRange("maxTwigsPerChunk", 3, 0, 256);
+        TOOL_NEUTERING = COMMON_BUILDER
+                .comment("Make disabled tools completely useless - can't even break grass.")
+                .define("toolNeutering", false);
         REMOVE_WOODEN_TOOL_FUNC = COMMON_BUILDER.comment(
                 "Setting this to true prevents the ability to use wooden tools, though you can still craft them for compatibility.")
                 .define("removeWoodenToolFunctionality", true);

--- a/src/main/java/com/oitsjustjose/natprog/common/event/ToolNeutering.java
+++ b/src/main/java/com/oitsjustjose/natprog/common/event/ToolNeutering.java
@@ -38,6 +38,8 @@ public class ToolNeutering {
 
     @SubscribeEvent
     public void registerEvent(PlayerEvent.BreakSpeed event) {
+        if (!CommonConfig.TOOL_NEUTERING.get()) return;
+
         if (event.getState() == null || event.getPlayer() == null) {
             return;
         }


### PR DESCRIPTION
`toolNeutering (boolean)` has been added to optionally keep some functionality for disabled tools. Like breaking grass and leaves.